### PR TITLE
Fix for issue #13

### DIFF
--- a/graphite_influxdb.py
+++ b/graphite_influxdb.py
@@ -29,7 +29,7 @@ class NullStatsd():
         pass
 
     def timer(self, key, val=None):
-        pass
+        return self
 
     def timing(self, key, val):
         pass


### PR DESCRIPTION
`with statsd.timer(‘…’)` expects an object to be returned, so `pass` is
not going to work for this call…
