### PR TITLE
Cyclical dependency on cache import fix - performance enhancements

### DIFF
--- a/graphite_influxdb.py
+++ b/graphite_influxdb.py
@@ -1,46 +1,22 @@
 import re
 import time
+import logging
+from logging.handlers import TimedRotatingFileHandler
 
-# graphite-api and graphite-web have different logging systems
+logger = logging.getLogger('graphite_influxdb')
+
 try:
     from graphite_api.intervals import Interval, IntervalSet
     from graphite_api.node import LeafNode, BranchNode
-    import structlog
-    logger = structlog.get_logger()
 except ImportError:
-    from graphite.intervals import Interval, IntervalSet
-    from graphite.node import LeafNode, BranchNode
-    from graphite.logger import log
-    import logging
-
-    class StructlogCompat(object):
-        def __init__(self):
-            log.debugLogger = logging.getLogger("debug")
-
-        @staticmethod
-        def debug(*args, **kwargs):
-            if not log.infoLogger.isEnabledFor(logging.DEBUG):
-                return
-
-            args_list = []
-            for arg in args:
-                args_list.append(arg)
-            for key, value in kwargs.iteritems():
-                args_list.append(key + '=' + str(value))
-            return log.infoLogger.debug(' '.join(args_list))
-    logger = StructlogCompat()
-# uncomment following to enable debugging logger
-#    log.infoLogger.setLevel(logging.DEBUG)
+    try:
+        from graphite.intervals import Interval, IntervalSet
+        from graphite.node import LeafNode, BranchNode
+    except ImportError:
+        raise SystemExit(1, "You have neither graphite_api nor \
+    the graphite webapp in your pythonpath")
 
 from influxdb import InfluxDBClient
-
-# uncomment the following block if you suspect that logger output is often not visible for some reason, but printing works, when you ctrl-c gunicorn at least (this is still a mystery to me)
-
-# def debug(*args, **kwargs):
-#    import pprint
-#    pprint.pprint((args, kwargs))
-# logger.debug = debug
-
 
 class NullStatsd():
     def __enter__(self):
@@ -90,6 +66,8 @@ def normalize_config(config=None):
         ret['passw'] = cfg.get('pass', 'graphite')
         ret['db'] = cfg.get('db', 'graphite')
         ret['schema'] = cfg.get('schema', [])
+        ret['log_file'] = cfg.get('log_file', None)
+        ret['log_level'] = cfg.get('log_level', 'info')
     else:
         from django.conf import settings
         ret['host'] = getattr(settings, 'INFLUXDB_HOST', 'localhost')
@@ -98,8 +76,11 @@ def normalize_config(config=None):
         ret['passw'] = getattr(settings, 'INFLUXDB_PASS', 'graphite')
         ret['db'] = getattr(settings, 'INFLUXDB_DB', 'graphite')
         ret['schema'] = getattr(settings, 'INFLUXDB_SCHEMA', [])
+        ret['log_file'] = getattr(
+            settings, 'INFLUXDB_LOG_FILE', None)
+        ret['log_level'] = getattr(
+            settings, 'INFLUXDB_LOG_LEVEL', 'info')
     return ret
-
 
 class InfluxdbReader(object):
     __slots__ = ('client', 'path', 'step', 'cache')
@@ -115,20 +96,19 @@ class InfluxdbReader(object):
         # from is exclusive (from=foo returns data at ts=foo+1 and higher)
         # until is inclusive (until=bar returns data at ts=bar and lower)
         # influx doesn't support <= and >= yet, hence the add.
-        logger.debug(caller="fetch()", start_time=start_time, end_time=end_time, step=self.step, debug_key=self.path)
+        # logger.debug(caller="fetch()", start_time=start_time, end_time=end_time, step=self.step, debug_key=self.path)
         with statsd.timer('service=graphite-api.ext_service=influxdb.target_type=gauge.unit=ms.what=query_individual_duration'):
-            data = self.client.query('select time, value from "%s" where time > %ds '
-                                     'and time < %ds order asc' % (
-                                         self.path, start_time, end_time + 1))
-
-        logger.debug(caller="fetch()", returned_data=data, debug_key=self.path)
-
+            _query = 'select time, value from "%s" where time > %ds and time < %ds order asc' % (
+                self.path, start_time, end_time + 1)
+            logger.debug("Calling influxdb with query - %s" % _query)
+            data = self.client.query(_query)
+        # logger.debug(caller="fetch()", returned_data=data, debug_key=self.path)
         try:
             known_points = data[0]['points']
         except Exception:
-            logger.debug(caller="fetch()", msg="COULDN'T READ POINTS. SETTING TO EMPTY LIST", debug_key=self.path)
+            # logger.debug(caller="fetch()", msg="COULDN'T READ POINTS. SETTING TO EMPTY LIST", debug_key=self.path)
             known_points = []
-        logger.debug(caller="fetch()", msg="invoking fix_datapoints()", debug_key=self.path)
+        # logger.debug(caller="fetch()", msg="invoking fix_datapoints()", debug_key=self.path)
         datapoints = InfluxdbReader.fix_datapoints(known_points, start_time, end_time, self.step, self.path)
 
         time_info = start_time, end_time, self.step
@@ -145,7 +125,7 @@ class InfluxdbReader(object):
             ....
         """
         for seriesdata in data:
-            logger.debug(caller="fix_datapoints_multi", msg="invoking fix_datapoints()", debug_key=seriesdata['name'])
+            # logger.debug(caller="fix_datapoints_multi", msg="invoking fix_datapoints()", debug_key=seriesdata['name'])
             datapoints = InfluxdbReader.fix_datapoints(seriesdata['points'], start_time, end_time, step, seriesdata['name'])
             out[seriesdata['name']] = datapoints
         return out
@@ -155,12 +135,12 @@ class InfluxdbReader(object):
         """
         points is a list of known points (potentially empty)
         """
-        logger.debug(caller='fix_datapoints', len_known_points=len(known_points), debug_key=debug_key)
-        if len(known_points) == 1:
-            logger.debug(caller='fix_datapoints', only_known_point=known_points[0], debug_key=debug_key)
-        elif len(known_points) > 1:
-            logger.debug(caller='fix_datapoints', first_known_point=known_points[0], debug_key=debug_key)
-            logger.debug(caller='fix_datapoints', last_known_point=known_points[-1], debug_key=debug_key)
+        # logger.debug(caller='fix_datapoints', len_known_points=len(known_points), debug_key=debug_key)
+        # if len(known_points) == 1:
+        #     logger.debug(caller='fix_datapoints', only_known_point=known_points[0], debug_key=debug_key)
+        # elif len(known_points) > 1:
+        #     logger.debug(caller='fix_datapoints', first_known_point=known_points[0], debug_key=debug_key)
+        #     logger.debug(caller='fix_datapoints', last_known_point=known_points[-1], debug_key=debug_key)
 
         datapoints = []
         steps = int(round((end_time - start_time) * 1.0 / step))
@@ -170,11 +150,11 @@ class InfluxdbReader(object):
         statsd.timer('service=graphite-api.target_type=gauge.unit=none.what=known_points/needed_points', ratio)
 
         if len(known_points) == steps + 1:
-            logger.debug(action="No steps missing", debug_key=debug_key)
+            # logger.debug(action="No steps missing", debug_key=debug_key)
             datapoints = [p[2] for p in known_points]
         else:
             amount = steps + 1 - len(known_points)
-            logger.debug(action="Fill missing steps with None values", amount=amount, debug_key=debug_key)
+            # logger.debug(action="Fill missing steps with None values", amount=amount, debug_key=debug_key)
             next_point = 0
             for s in range(0, steps + 1):
                 # if we have no more known points, fill with None's
@@ -202,9 +182,9 @@ class InfluxdbReader(object):
                 else:
                     datapoints.append(None)
 
-        logger.debug(caller='fix_datapoints', len_known_points=len(known_points), len_datapoints=len(datapoints), debug_key=debug_key)
-        logger.debug(caller='fix_datapoints', first_returned_point=datapoints[0], debug_key=debug_key)
-        logger.debug(caller='fix_datapoints', last_returned_point=datapoints[-1], debug_key=debug_key)
+        # logger.debug(caller='fix_datapoints', len_known_points=len(known_points), len_datapoints=len(datapoints), debug_key=debug_key)
+        # logger.debug(caller='fix_datapoints', first_returned_point=datapoints[0], debug_key=debug_key)
+        # logger.debug(caller='fix_datapoints', last_returned_point=datapoints[-1], debug_key=debug_key)
         return datapoints
 
     def get_intervals(self):
@@ -227,10 +207,30 @@ class InfluxdbFinder(object):
         except:
             from django.core.cache import cache
             self.cache = cache
-
+        # import ipdb; ipdb.set_trace()
         config = normalize_config(config)
         self.client = InfluxDBClient(config['host'], config['port'], config['user'], config['passw'], config['db'])
         self.schemas = [(re.compile(patt), step) for (patt, step) in config['schema']]
+        self._setup_logger(config['log_level'], config['log_file'])
+
+    def _setup_logger(self, level, log_file):
+        """Setup log level and log file if set"""
+        level = getattr(logging, level.upper())
+        logger.setLevel(level)
+        formatter = logging.Formatter(
+            '[%(levelname)s] %(asctime)s - %(module)s.%(funcName)s() - %(message)s')
+        if not log_file:
+            return
+        try:
+            handler = TimedRotatingFileHandler(log_file)
+        except IOError:
+            handler = logging.StreamHandler()
+            logger.addHandler(handler)
+            logger.error("Could not write to %s, falling back to stdout",
+                         log_file)
+        else:
+            logger.addHandler(handler)
+        handler.setFormatter(formatter)
 
     def assure_series(self, query):
         regex = self.compile_regex(query, True)
@@ -240,11 +240,12 @@ class InfluxdbFinder(object):
             series = self.cache.get(key_series)
         if series is not None:
             return series
-
         # if not in cache, generate from scratch
         # first we must load the list with all nodes
         with statsd.timer('service=graphite-api.ext_service=influxdb.target_type=gauge.unit=ms.action=get_series'):
-            ret = self.client.query("list series /%s/" % regex.pattern)
+            _query = "list series /%s/" % regex.pattern
+            ret = self.client.query(_query)
+            logger.debug("Calling influxdb with query - %s" % _query)
             # as long as influxdb doesn't have good safeguards against series with bad data in the metric names, we must filter out like so:
             series = [serie[1] for serie in ret[0]['points'] if serie[1].encode('ascii', 'ignore') == serie[1]]
 
@@ -266,43 +267,45 @@ class InfluxdbFinder(object):
         regex = regex.format(
             query.pattern.replace('.', '\.').replace('*', '[^\.]*').replace('{', '(').replace(',', '|').replace('}', ')')
         )
-        logger.debug("searching for nodes", pattern=query.pattern, regex=regex)
+        # logger.debug("searching for nodes", pattern=query.pattern, regex=regex)
         return re.compile(regex)
 
     def get_leaves(self, query):
         key_leaves = "%s_leaves" % query.pattern
-        with statsd.timer('service=graphite-api.action=cache_get_leaves.target_type=gauge.unit=ms'):
-            data = self.cache.get(key_leaves)
-        if data is not None:
-            return data
+        # with statsd.timer('service=graphite-api.action=cache_get_leaves.target_type=gauge.unit=ms'):
+        #     data = self.cache.get(key_leaves)
+        # if data is not None:
+        #     return data
+        data = None
         series = self.assure_series(query)
         regex = self.compile_regex(query)
-        logger.debug(caller="get_leaves", key=key_leaves)
+        # logger.debug(caller="get_leaves", key=key_leaves)
         leaves = []
         with statsd.timer('service=graphite-api.action=find_leaves.target_type=gauge.unit=ms'):
             for name in series:
                 if regex.match(name) is not None:
-                    logger.debug("found leaf", name=name)
+                    # logger.debug("found leaf", name=name)
                     res = 60  # fallback default
                     for (rule_patt, rule_res) in self.schemas:
                         if rule_patt.match(name):
                             res = rule_res
                             break
                     leaves.append([name, res])
-        with statsd.timer('service=graphite-api.action=cache_set_leaves.target_type=gauge.unit=ms'):
-            self.cache.add(key_leaves, leaves, timeout=300)
+        # with statsd.timer('service=graphite-api.action=cache_set_leaves.target_type=gauge.unit=ms'):
+        #     self.cache.add(key_leaves, leaves, timeout=300)
         return leaves
 
     def get_branches(self, query):
         seen_branches = set()
         key_branches = "%s_branches" % query.pattern
-        with statsd.timer('service=graphite-api.action=cache_get_branches.target_type=gauge.unit=ms'):
-            data = self.cache.get(key_branches)
-        if data is not None:
-            return data
+        # with statsd.timer('service=graphite-api.action=cache_get_branches.target_type=gauge.unit=ms'):
+        #     data = self.cache.get(key_branches)
+        # if data is not None:
+        #     return data
+        data = None
         series = self.assure_series(query)
         regex = self.compile_regex(query)
-        logger.debug(caller="get_branches", key=key_branches)
+        # logger.debug(caller="get_branches", key=key_branches)
         branches = []
         with statsd.timer('service=graphite-api.action=find_branches.target_type=gauge.unit=ms'):
             for name in series:
@@ -311,13 +314,15 @@ class InfluxdbFinder(object):
                     if name not in seen_branches:
                         seen_branches.add(name)
                         if regex.match(name) is not None:
-                            logger.debug("found branch", name=name)
+                            # logger.debug("found branch", name=name)
                             branches.append(name)
-        with statsd.timer('service=graphite-api.action=cache_set_branches.target_type=gauge.unit=ms'):
-            self.cache.add(key_branches, branches, timeout=300)
+        # with statsd.timer('service=graphite-api.action=cache_set_branches.target_type=gauge.unit=ms'):
+        #     self.cache.add(key_branches, branches, timeout=300)
         return branches
 
     def find_nodes(self, query):
+        # import ipdb; ipdb.set_trace()
+        # logger.debug("Got find nodes query %s" % query.pattern)
         # TODO: once we can query influx better for retention periods, honor the start/end time in the FindQuery object
         with statsd.timer('service=graphite-api.action=yield_nodes.target_type=gauge.unit=ms.what=query_duration'):
             for (name, res) in self.get_leaves(query):
@@ -333,18 +338,20 @@ class InfluxdbFinder(object):
         step = max([node.reader.step for node in nodes])
         query = 'select time, value from %s where time > %ds and time < %ds order asc' % (
                 series, start_time, end_time + 1)
-        logger.debug(caller='fetch_multi', query=query)
-        logger.debug(caller='fetch_multi', start_time=print_time(start_time), end_time=print_time(end_time), step=step)
+        # logger.debug(caller='fetch_multi', query=query)
+        # logger.debug(caller='fetch_multi', start_time=print_time(start_time), end_time=print_time(end_time), step=step)
         with statsd.timer('service=graphite-api.ext_service=influxdb.target_type=gauge.unit=ms.action=select_datapoints'):
+            # import ipdb; ipdb.set_trace()
+            logger.debug("Calling influxdb multi fetch with query - %s" % query)
             data = self.client.query(query)
-        logger.debug(caller='fetch_multi', returned_data=data)
+        # logger.debug(caller='fetch_multi', returned_data=data)
         if not len(data):
             data = [{'name': node.path, 'points': []} for node in nodes]
-            logger.debug(caller='fetch_multi', FIXING_DATA_TO=data)
-        logger.debug(caller='fetch_multi', len_datapoints_before_fixing=len(data))
+            # logger.debug(caller='fetch_multi', FIXING_DATA_TO=data)
+        # logger.debug(caller='fetch_multi', len_datapoints_before_fixing=len(data))
 
         with statsd.timer('service=graphite-api.action=fix_datapoints_multi.target_type=gauge.unit=ms'):
-            logger.debug(caller='fetch_multi', action='invoking fix_datapoints_multi()')
+            # logger.debug(caller='fetch_multi', action='invoking fix_datapoints_multi()')
             datapoints = InfluxdbReader.fix_datapoints_multi(data, start_time, end_time, step)
 
         time_info = start_time, end_time, step


### PR DESCRIPTION
Hello,

This pull request has the following changes:

 - Fix for #34 
 - Modified the `get_branches` algorithm to be more efficient. This has resulted in a saving of 0.5sec *per `get_branches` query* in my testing.
 - Simplified logging and allowed for log configuration specific to graphite_influxdb. For example, in a graphite-api.yaml file that looks like the below.
 - Fixed issue where graphite_influxdb would not work if a cache is not configured in either graphite_api nor django graphite webapp. Cache not being configured resulted in `self.cache` object in `graphite_influxdb.InfluxdbFinder` to be `None` and calls to `self.cache.<add|get>` would fail with an `AttributeError`.
   Added `FakeCache` class to act as a noop cache object when cache is not configured.

graphite_api.yaml sample with separate graphite_influxdb log file and configuration
```
search_index: /opt/graphite/storage/index
finders:
  - graphite_influxdb.InfluxdbFinder
influxdb:
   host: localhost
   port: 8086
   user: root
   pass: root
   db:   graphite
   schema:
     - ['', 1]
   log_file: /var/log/graphite_handler/graphite_handler.log
   log_level: debug
time_zone: UTC
```

Note that due to the attempts to `from graphite_api.app import app` more cyclical dependencies exist depending on the graphite-api configuration file and what is enabled in the config.

Strongly urge to remove any and all attempts to import from `graphite_api.app` as `graphite_api.app` will always try to load `graphite_influxdb.InfluxdbFinder` *on import* which causes a cyclical dependency `graphite_influxdb.InfluxdbFinder` -> `graphite_api.app` -> `graphite_influxdb.InfluxdbFinder`.

Have not changed the other imports as it would remove statsd support and caching support from graphite-api.
