### PR TITLE
Use client for InfluxDB version 0.8.x

### DIFF
--- a/graphite_influxdb.py
+++ b/graphite_influxdb.py
@@ -3,7 +3,7 @@ import time
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import datetime
-from influxdb import InfluxDBClient
+from influxdb.influxdb08 import InfluxDBClient
 
 logger = logging.getLogger('graphite_influxdb')
 


### PR DESCRIPTION
Recent versions of the InfluxDB client already use the InfluxDB 0.9.x
API. To use the API for 0.8.x, the legacy client has to be imported
explicitly. Fixes issue #44.